### PR TITLE
Support for uploading Posts and Stories from a "file-like" objects

### DIFF
--- a/instabot/api/api_photo.py
+++ b/instabot/api/api_photo.py
@@ -83,18 +83,18 @@ def compatible_aspect_ratio(size):
 def configure_photo(self, upload_id, photo_size, caption="", user_tags=None, is_sidecar=False):
     width, height = photo_size
     data = {
-            "media_folder": "Instagram",
-            "source_type": 4,
-            "caption": caption,
-            "upload_id": upload_id,
-            "device": self.device_settings,
-            "edits": {
-                "crop_original_size": [width * 1.0, height * 1.0],
-                "crop_center": [0.0, 0.0],
-                "crop_zoom": 1.0,
-            },
-            "extra": {"source_width": width, "source_height": height},
-        }
+        "media_folder": "Instagram",
+        "source_type": 4,
+        "caption": caption,
+        "upload_id": upload_id,
+        "device": self.device_settings,
+        "edits": {
+            "crop_original_size": [width * 1.0, height * 1.0],
+            "crop_center": [0.0, 0.0],
+            "crop_zoom": 1.0,
+        },
+        "extra": {"source_width": width, "source_height": height},
+    }
     if user_tags:
         data['usertags'] = user_tags
 

--- a/instabot/api/api_photo.py
+++ b/instabot/api/api_photo.py
@@ -309,6 +309,7 @@ def resize_image(img):
     v_lim = {"w": 4.0, "h": 5.0}
     (w, h) = img.size
     deg = 0
+
     try:
         for orientation in ExifTags.TAGS.keys():
             if ExifTags.TAGS[orientation] == "Orientation":
@@ -325,12 +326,14 @@ def resize_image(img):
             print("Rotating by {d} degrees".format(d=deg))
             img = img.rotate(deg, expand=True)
             (w, h) = img.size
+
     except (AttributeError, KeyError, IndexError) as e:
         print("No exif info found (ERR: {err})".format(err=e))
-        pass
+
     img = img.convert("RGBA")
     ratio = w * 1.0 / h * 1.0
     print("FOUND w:{w}, h:{h}, ratio={r}".format(w=w, h=h, r=ratio))
+
     if w > h:
         print("Horizontal image")
         if ratio > (h_lim["w"] / h_lim["h"]):
@@ -347,6 +350,7 @@ def resize_image(img):
             nw = 1080
             nh = int(ceil(1080.0 * h / w))
             img = img.resize((nw, nh), Image.ANTIALIAS)
+
     elif w < h:
         print("Vertical image")
         if ratio < (v_lim["w"] / v_lim["h"]):
@@ -363,11 +367,13 @@ def resize_image(img):
             nw = int(ceil(1080.0 * w / h))
             nh = 1080
             img = img.resize((nw, nh), Image.ANTIALIAS)
+
     else:
         print("Square image")
         if w > 1080:
             print("Resizing image")
             img = img.resize((1080, 1080), Image.ANTIALIAS)
+
     (w, h) = img.size
     new = Image.new("RGB", img.size, (255, 255, 255))
     new.paste(img, (0, 0, w, h), img)

--- a/instabot/api/api_photo.py
+++ b/instabot/api/api_photo.py
@@ -9,6 +9,8 @@ import time
 import random
 from uuid import uuid4
 
+from PIL import Image, ExifTags
+from math import ceil
 
 from . import config
 
@@ -299,22 +301,12 @@ def get_image_size(fname):
         return width, height
 
 
-def resize_image(fname):
-    from math import ceil
+def resize_image(img):
+    """ Recives a PIL image object, and returns another PIL resized image
+    object - to match Instagram's post sizes. """
 
-    try:
-        from PIL import Image, ExifTags
-    except ImportError as e:
-        print("ERROR: {err}".format(err=e))
-        print(
-            "Required module `PIL` not installed\n"
-            "Install with `pip install Pillow` and retry"
-        )
-        return False
-    print("Analizing `{fname}`".format(fname=fname))
     h_lim = {"w": 90.0, "h": 47.0}
     v_lim = {"w": 4.0, "h": 5.0}
-    img = Image.open(fname)
     (w, h) = img.size
     deg = 0
     try:
@@ -377,12 +369,9 @@ def resize_image(fname):
             print("Resizing image")
             img = img.resize((1080, 1080), Image.ANTIALIAS)
     (w, h) = img.size
-    new_fname = "{fname}.CONVERTED.jpg".format(fname=fname)
-    print("Saving new image w:{w} h:{h} to `{f}`".format(w=w, h=h, f=new_fname))
     new = Image.new("RGB", img.size, (255, 255, 255))
     new.paste(img, (0, 0, w, h), img)
-    new.save(new_fname, quality=95)
-    return new_fname
+    return new
 
 
 def stories_shaper(fname):


### PR DESCRIPTION
Currently, it is only possible to upload posts and stories using a string that points to a location in the storage (for example, `C:\Images\myimage.png`).
When dealing with automated programs, uploading an image from a "file-like" object, or a direct PIL image instance is very useful and makes the process of uploading the image much more clear (instead of saving the generated image in storage and then loading it again...)

**Anyway, this PR fixes the issue and adds support for uploading Images using "file-like" objects and a even a direct PIL image instance.**